### PR TITLE
Upgrade Spatial SDK to 0.5.2

### DIFF
--- a/Showcases/media_view/gradle.properties
+++ b/Showcases/media_view/gradle.properties
@@ -26,4 +26,4 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 # Common version for Meta Spatial SDK across the project
-metaSpatialSdkVersion=0.5.1
+metaSpatialSdkVersion=0.5.2


### PR DESCRIPTION
Used to open PR at the base Meta repo. Will merge once `0.5.2` becomes publicly available.